### PR TITLE
Updated the addon to now have `/scriptevent voicecraft:voice help`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# VoiceCraft Minecraft Bedrock Edition Proxmity Chat Addon
+# VoiceCraft Minecraft Bedrock Edition Proximity Chat Addon
 Addon for VoiceCraft
 
-If you have an issue/suggestion with the addon. Please create it on the main repository: https://github.com/SineVector241/VoiceCraft-MCBE_Proximity_Chat
+If you have an issue/suggestion with the addon. Please create it on the main repository: https://github.com/AvionBlock/VoiceCraft

--- a/VoiceCraft.Addon.BP/manifest.json
+++ b/VoiceCraft.Addon.BP/manifest.json
@@ -45,7 +45,7 @@
 	"dependencies": [
 		{
 			"module_name": "@minecraft/server",
-			"version": "1.14.0-beta"
+			"version": "1.17.0"
 		},
 		{
 			"module_name": "@minecraft/server-net",
@@ -53,7 +53,7 @@
 		},
 		{
 			"module_name": "@minecraft/server-ui",
-			"version": "1.1.0"
+			"version": "1.3.0"
 		}
 	]
 }

--- a/VoiceCraft.Addon.BP/scripts/Commands/CommandSystem.js
+++ b/VoiceCraft.Addon.BP/scripts/Commands/CommandSystem.js
@@ -81,7 +81,34 @@ class CommandSystem {
   }
 }
 
-world.beforeEvents.chatSend.subscribe((ev) => {
+system.afterEvents.scriptEventReceive.subscribe((event) => {
+  const {
+    id, // returns string (wiki:test)
+    initiator, // returns Entity (or undefined if an NPC did not fire the command)
+    message, // returns string (Hello World)
+    sourceBlock, // returns Block (or undefined if a block did not fire the command)
+    sourceEntity, // returns Entity (or undefined if an entity did not fire the command)
+    sourceType, // returns MessageSourceType (can be 'Block', 'Entity', 'NPCDialogue', or 'Server')
+  } = event;
+
+  // `/scriptevent voicecraft:voice help` -> !help
+
+  if (id.toLowerCase() === 'voicecraft:voice') {
+    let source = sourceEntity ?? initiator;
+    if (sourceType == 'Server' || source === undefined)  {
+      source = {
+        isOp: () => true,
+        sendMessage: function(message) {
+          console.log(message);
+        }
+      }
+    }
+    CommandSystem.executeCommand(CommandSystem.Prefix + message, source, event);
+  }
+});
+
+// No longer using this, but if beta api's are enabled, it will still work
+world?.beforeEvents?.chatSend?.subscribe?.((ev) => {
   CommandSystem.executeCommand(ev.message, ev.sender, ev);
 });
 

--- a/VoiceCraft.Addon.BP/scripts/Network/Network.js
+++ b/VoiceCraft.Addon.BP/scripts/Network/Network.js
@@ -35,7 +35,7 @@ import {
   VoiceCraftPlayer,
 } from "./MCCommAPI";
 import { NetworkRunner } from "./NetworkRunner";
-import { world, Player } from "@minecraft/server";
+import { world, Player, system } from "@minecraft/server";
 
 class Network {
   static Version = "1.0.0";
@@ -64,7 +64,7 @@ class Network {
         const key = ev.player.getDynamicProperty("VCAutoBind");
         if (key != null) {
           player.sendMessage(`§2Autobinding Enabled. §eBinding to key: ${key}`);
-          this.BindPlayer(key, player)
+          this.Bind(key, player)
             .then(() => {
               player.sendMessage("§aBinding Successful!");
             })
@@ -81,7 +81,7 @@ class Network {
       }
     });
 
-    world.afterEvents.worldInitialize.subscribe((ev) => {
+    system.run(() => {
       if (world.getDynamicProperty("autoConnectOnStart")) {
         console.warn("Auto connection enabled, Connecting to server...");
         this.AutoConnect()


### PR DESCRIPTION
Updated the addon to now use the scriptevent system instead of chat commands which was beta only.

Help command is: `/scriptevent voicecraft:voice help`

The addon should no longer be able to stop working when minecraft releases new scripting versions.

Also small fix for Network.js where autobind didn't work because wrong function name...